### PR TITLE
Add Floodlight Series F751W Firmware: v3.2.0.6530_2606232191

### DIFF
--- a/firmwares_manual.json
+++ b/firmwares_manual.json
@@ -1006,5 +1006,13 @@
     ],
     "sha256_pak": "af52bd3ebbba9c8620ed315ce257fc3ec07515db787a06bfa07b20c894690a76",
     "source": "manual"
+  },
+  {
+    "source_urls": [
+      "Download URL captured from Reolink desktop client"
+    ],
+    "note": "This firmware version is not listed on the Reolink download center. The download URL was obtained by capturing it from the Reolink desktop client when the update was offered through a pop-up. If Reolink ever removes this firmware version from their website, it can also be downloaded from the Internet Archive: https://web.archive.org/web/20260703170124/https://firmwares.cdn.reolink.com/device-ota/final-firmwares/Elite-Floodlight-WiFi.6530_2606232191.IPC_NT18NA68MPW.paks",
+    "file": "https://firmwares.cdn.reolink.com/device-ota/final-firmwares/Elite-Floodlight-WiFi.6530_2606232191.IPC_NT18NA68MPW.paks",
+    "source": "manual"
   }
 ]


### PR DESCRIPTION
Earlier today, the Reolink desktop client offered me an upgrade to v3.2.0.6530_2606232191 for my Floodlight Series F751W camera. This firmware version is not listed on the Reolink website.

<img width="1274" height="336" alt="image" src="https://github.com/user-attachments/assets/4b1461bb-cb6d-4b75-ad8f-c1e4e2d91156" />

Since it is not listed, I captured the download link from the client.

If Reolink ever removes this firmware version from their servers, it can also be downloaded from the Internet Archive: https://web.archive.org/web/20260703170124/https://firmwares.cdn.reolink.com/device-ota/final-firmwares/Elite-Floodlight-WiFi.6530_2606232191.IPC_NT18NA68MPW.paks

I have two F751W cameras but only one of them was offered the upgrade. For the camera that was not offered it, I manually installed it using the PAKS file from the captured link.

Unfortunately, there do not seem to be any changelogs available for the update.